### PR TITLE
adding callouts about unlinked accounts

### DIFF
--- a/start/account/2020-transition-guide.md
+++ b/start/account/2020-transition-guide.md
@@ -31,14 +31,15 @@ Follow these steps to ensure you have your data and can continue to submit jobs:
 and find the name of the login node that you've been assigned. The login node 
 information can be seen on your profile here: 
 ![Identify Login Node](https://raw.githubusercontent.com/OSGConnect/connectbook/master/images/find_osgconnect_login_node.png "OSG Connect Profile")
-> **IMPORTANT** If you log into the OSG Connect website with your institutional credentials 
-and it asks you to sign up for OSG / create a profile, do NOT create a new profile. Instead, do the following: 
-> * close the OSG Connect page and go to http://globus.org. 
-> * Log in with your Globus ID and go to "Account" on the left-hand menu.
-> * If your institutional identity is already listed on that Account page, [email the OSG Connect support team](mailto:support@osgconnect.net)
-> * If your institutional identity is NOT listed on the account page, select "Link Another Identity" on the 
-> right and add your institutional identity. Then go back to the OSG Connect website and try to 
-> log in again. 
+
+	> **IMPORTANT** If you log into the OSG Connect website with your institutional credentials 
+	and it asks you to sign up for OSG / create a profile, do NOT create a new profile. Instead, do the following: 
+	> * close the OSG Connect page and go to http://globus.org. 
+	> * Log in with your Globus ID and go to "Account" on the left-hand menu.
+	> * If your institutional identity is already listed on that Account page, [email the OSG Connect support team](mailto:support@osgconnect.net)
+	> * If your institutional identity is NOT listed on the account page, select "Link Another Identity" on the 
+	> right and add your institutional identity. Then go back to the OSG Connect website and try to 
+	> log in again. 
 
 1. Log into the new login node and set your primary project. Follow the instructions 
 at the bottom of the OSG project guide: [Join and Use a Project in OSG Connect](5000634360)

--- a/start/account/2020-transition-guide.md
+++ b/start/account/2020-transition-guide.md
@@ -32,6 +32,16 @@ and find the name of the login node that you've been assigned. The login node
 information can be seen on your profile here: 
 ![Identify Login Node](https://raw.githubusercontent.com/OSGConnect/connectbook/master/images/find_osgconnect_login_node.png "OSG Connect Profile")
 
+> **IMPORTANT** If you log into the OSG Connect website with your institutional credentials 
+and it asks you to sign up for OSG / create a profile, do NOT create a new profile. Instead, do the following: 
+> * close the OSG Connect page and go to http://globus.org. 
+> * Log in with your Globus ID and go to "Account" on the left-hand menu.
+> * If your institutional identity is already listed on that Account page, [email the OSG Connect support team](mailto:support@osgconnect.net)
+> * If your institutional identity is NOT listed on the account page, select "Link Another Identity" on the 
+> right and add your institutional identity. Then go back to the OSG Connect website and try to 
+> log in again. 
+
+
 1. Log into the new login node and set your primary project. Follow the instructions 
 at the bottom of the OSG project guide: [Join and Use a Project in OSG Connect](5000634360)
 

--- a/start/account/2020-transition-guide.md
+++ b/start/account/2020-transition-guide.md
@@ -31,7 +31,6 @@ Follow these steps to ensure you have your data and can continue to submit jobs:
 and find the name of the login node that you've been assigned. The login node 
 information can be seen on your profile here: 
 ![Identify Login Node](https://raw.githubusercontent.com/OSGConnect/connectbook/master/images/find_osgconnect_login_node.png "OSG Connect Profile")
-
 > **IMPORTANT** If you log into the OSG Connect website with your institutional credentials 
 and it asks you to sign up for OSG / create a profile, do NOT create a new profile. Instead, do the following: 
 > * close the OSG Connect page and go to http://globus.org. 
@@ -40,7 +39,6 @@ and it asks you to sign up for OSG / create a profile, do NOT create a new profi
 > * If your institutional identity is NOT listed on the account page, select "Link Another Identity" on the 
 > right and add your institutional identity. Then go back to the OSG Connect website and try to 
 > log in again. 
-
 
 1. Log into the new login node and set your primary project. Follow the instructions 
 at the bottom of the OSG project guide: [Join and Use a Project in OSG Connect](5000634360)

--- a/start/account/registration-and-login.md
+++ b/start/account/registration-and-login.md
@@ -31,6 +31,8 @@ service which asks you what your home institution is. (If you've used CILogon
 before it may already know your home institution and skip this step.) Locate
 your institution in the list, or type its name to find matches. 
 
+> **No Institutional Identity?**
+> 
 > If you don't have an institutional identity or can't find your institution 
 > on the provided list, either (separately) sign up for a Globus ID and follow 
 > the link for that option on this page, or contact the OSG Connect support 
@@ -45,6 +47,13 @@ your own institution's local sign-in screen. You've probably used it before,
 and if it looks familiar that's because it's exactly the same web site.  Sign in
 using your campus credentials. When done, you'll return automatically to the
 OSG Connect portal and can carry on with signup.
+
+> **Returning to OSG Connect**?
+> 
+> If you already have an OSG Connect account and are not being taken to your 
+> profile page after logging in with your institution's credentials, 
+> see our [transition guide](12000065909#action-items) for 
+> how to proceed.
 
 After continuing, and allowing certain permissions in the next screen, you'll be 
 asked to create a profile and save changes. If this works successfully, you should 


### PR DESCRIPTION
This is (hopefully) to catch those people who didn't link their institutional w/ Globus originally and are being prompted to create a new account when they sign into the new OSG Connect website for the first time w/ their institutional credential. 