### PR TITLE
Update software guides

### DIFF
--- a/start/software/compiling-applications.md
+++ b/start/software/compiling-applications.md
@@ -6,7 +6,10 @@
 
 Due to the distributed nature of the Open Science Grid, you will always need to 
 ensure that your jobs have access to the software that will be executed. This guide provides 
-useful information, including an [example](#example-compilation), for compiling and using your software in OSG Connect. 
+useful information for compiling and using your software in OSG Connect. A detailed 
+example of performing software compilation is additionally available 
+at (link). 
+
 
 > *What is compiling?*
 > The process of compiling converts human readable code into binary, 

--- a/start/software/compiling-applications.md
+++ b/start/software/compiling-applications.md
@@ -33,8 +33,8 @@ required for your software.
 A compiler is a program that is used to peform source code compilation. The GNU Compiler 
 Collection (GCC) is a common, open source collection of compilers with support for C, C++, 
 fotran, and other languages, and includes important libraries for supporting your compilation 
-and sometimes software executation. Your software compilation may require certain versions 
-of a compiler which should be noted in the installtion instructions or system dependencies 
+and sometimes software execution. Your software compilation may require certain versions 
+of a compiler which should be noted in the installation instructions or system dependencies 
 documention. Currently the login nodes have `GCC 4.8.5` as the default version, but newer 
 versions of GCC may also be available - to learn more please contact <support@osgconnect.net>.
 
@@ -50,7 +50,7 @@ final binary to be "dynamically linked" to libraries that it depends on, such th
 the binary is executed, it will look for these library files on the system that it is 
 running on. Thus a copy of the appropriate library files will need to be available to your 
 software wherever it runs. OSG Connect users can transfer a copy of the necessary 
-libraries alog with with their jobs to manage such dependencies if not supported by the 
+libraries along with with their jobs to manage such dependencies if not supported by the 
 execute node that your jobs run on.
 
 However, the option exists to "statically link" the library dependencies of your software. 
@@ -100,7 +100,7 @@ nodes with specific operating systems, for instance:
 	requirements = (OSGVO_OS_STRING == "RHEL 7")
 
 Software installation typically includes three steps: 1.) configuration, 2.) compilation, and 3.) 
-"installation" which places the compiled code in specific location. In most cases, 
+"installation" which places the compiled code in a specific location. In most cases, 
 these steps will be achieved with the following commands:
 
 	./configure
@@ -109,7 +109,7 @@ these steps will be achieved with the following commands:
 
 **Most software is written to install to a default location, however your OSG Connect 
 account is not authorized to write to these default system locations.** Instead, you will want to 
-create a folder for your software installation in your `home` directory use an option in the 
+create a folder for your software installation in your `home` directory and use an option in the 
 configuration step that will install the software to this folder:
 
 	./configure --prefix=/home/username/path
@@ -123,7 +123,7 @@ When submitting jobs, you will need to transfer a copy of your compiled software
 and any dynamically-linked dependencies that you also installed. Our 
 [Introduction to Data Management on OSG Connect](https://support.opensciencegrid.org/support/solutions/articles/12000002985) 
 guide is a good starting point for more information for selecting the appropriate
-methods for transferring you software. Depending on your job workfloe, it may be possible 
+methods for transferring you software. Depending on your job workflow, it may be possible 
 to directly specify your executable binary as the `executable` in your HTCondor 
 submit file.
 

--- a/start/software/compiling-applications.md
+++ b/start/software/compiling-applications.md
@@ -114,38 +114,19 @@ configuration step that will install the software to this folder:
 where `username` should be replaced with your OSG Connect username and `path` replaced with the 
 path to the directory you created for your software installation.
 
-## Example Compilation
+## Use Your Software
 
-He we provide an example of compiling software for use via OSG Connect using the common bioinformatics 
-program Samtools.
+When submitting jobs, you will need to transfer a copy of your compiled software, 
+and any dynamically-linked dependencies that you also installed. Our 
+[Introduction to Data Management on OSG Connect](https://support.opensciencegrid.org/support/solutions/articles/12000002985) 
+guide is a good starting point for more information for selecting the appropriate
+methods for transferring you software. Depending on your job workfloe, it may be possible 
+to directly specify your executable binary as the `executable` in your HTCondor 
+submit file.
 
-### Step 1. Acquire Samtools source code
-
-Samtools source code is available at [http://www.htslib.org/download/](http://www.htslib.org/download/). The 
-development code is also available via GitHub at [https://github.com/samtools/samtools](https://github.com/samtools/samtools).
-
-Either download the Samtools source code to your co
-Right-click on the Samtools source code link and copy the link location. Login in to your OSG Connect login 
-and use `wget` to download the source code directly and extract the tarball:
-
-	wget https://github.com/samtools/samtools/releases/download/1.10/samtools-1.10.tar.bz2
-	tar -xjf samtools-1.10.tar.bz2
-
-The above two commands will create directory named `samtools-1.10` which contains all the code 
-needed for compiling Samtools.
-
-### Step 2. Read through installation instructions
-
-The HTSlib website page where the Samtools source code is hosted provides basic installation instructions 
-and refers to `INSTALL` for more information. Source code directories will always include a `README` 
-file with important information including where to get detailed installation instructions. 
-
-`cd` to samtools-1.10 and read through `README` and `INSTALL`. As described in `INSTALL`, there are 
-a number of required and optional system dependencies for installing Samtools. Some dependencies are 
-needed to support certain features from Samtools (such as `tview` and CRAM). You will not need `tview` 
-as this is intended for interactive work which is not currently supported in OSG Connect.
-
-
+When using your software in subsequent job submissions, be sure to add additional  
+commands to the executable bash script to define evironment variables, like
+for instance `LD_LIBRARY_PATH`, that may be needed to properly execute your software.
 
 ## Get Additional Assistance
 If you have questions or need assistance, please contact <support@osgconnect.net>.

--- a/start/software/compiling-applications.md
+++ b/start/software/compiling-applications.md
@@ -5,7 +5,7 @@
 
 Due to the distributed nature of the Open Science Grid, you will always need to 
 ensure that your jobs have access to the software that will be executed. This guide provides 
-useful information and examples for compiling and using your software in OSG Connect. 
+useful information, including an [example](#example-compilation), for compiling and using your software in OSG Connect. 
 
 > *What is compiling?*
 > The process of compiling converts ASCII (i.e. human readable) code into binary, 
@@ -116,6 +116,39 @@ configuration step that will install the software to this folder:
 
 where `username` should be replaced with your OSG Connect username and `path` replaced with the 
 path to the directory you created for your software installation.
+
+## Example Compilation
+
+He we provide an example of compiling software for use via OSG Connect using the common bioinformatics 
+program Samtools.
+
+### Step 1. Acquire Samtools source code
+
+Samtools source code is available at [http://www.htslib.org/download/](http://www.htslib.org/download/). The 
+development code is also available via GitHub at [https://github.com/samtools/samtools](https://github.com/samtools/samtools).
+
+Either download the Samtools source code to your co
+Right-click on the Samtools source code link and copy the link location. Login in to your OSG Connect login 
+and use `wget` to download the source code directly and extract the tarball:
+
+	wget https://github.com/samtools/samtools/releases/download/1.10/samtools-1.10.tar.bz2
+	tar -xjf samtools-1.10.tar.bz2
+
+The above two commands will create directory named `samtools-1.10` which contains all the code 
+needed for compiling Samtools.
+
+### Step 2. Read through installation instructions
+
+The HTSlib website page where the Samtools source code is hosted provides basic installation instructions 
+and refers to `INSTALL` for more information. Source code directories will always include a `README` 
+file with important information including where to get detailed installation instructions. 
+
+`cd` to samtools-1.10 and read through `README` and `INSTALL`. As described in `INSTALL`, there are 
+a number of required and optional system dependencies for installing Samtools. Some dependencies are 
+needed to support certain features from Samtools (such as `tview` and CRAM). You will not need `tview` 
+as this is intended for interactive work which is not currently supported in OSG Connect.
+
+
 
 ## Get Additional Assistance
 If you have questions or need assistance, please contact <support@osgconnect.net>.

--- a/start/software/compiling-applications.md
+++ b/start/software/compiling-applications.md
@@ -97,7 +97,7 @@ compatible for execution on RHEL 7 or similar operating systems. You can use the
 `requirements` statement of your HTCondor submit file to direct your jobs to execute 
 nodes with specific operating systems, for instance:
 
-	requirements = (OpSysAndVer =?= "SL7") || (OpSysAndVer=?= "RHEL7") || (OpSysAndVer =?= "Centos7")
+	requirements = (OSGVO_OS_STRING == "RHEL 7")
 
 Software installation typically includes three steps: 1.) configuration, 2.) compilation, and 3.) 
 "installation" which places the compiled code in specific location. In most cases, 

--- a/start/software/compiling-applications.md
+++ b/start/software/compiling-applications.md
@@ -8,7 +8,7 @@ Due to the distributed nature of the Open Science Grid, you will always need to
 ensure that your jobs have access to the software that will be executed. This guide provides 
 useful information for compiling and using your software in OSG Connect. A detailed 
 example of performing software compilation is additionally available 
-at (link). 
+at [OSG Connect Example Compilation Guide](https://support.opensciencegrid.org/support/solutions/articles/12000074984). 
 
 
 > *What is compiling?*

--- a/start/software/compiling-applications.md
+++ b/start/software/compiling-applications.md
@@ -1,57 +1,121 @@
-[title]: - "Compiling Applications for OSG Connect"
+[title]: - "Compiling Software for OSG Connect"
 
-# Compiling Applications for OSG Connect
+# Compiling Software for OSG Connect
 ## Introduction
-If you are using software that is primarily distributed as source code
-or if you need to compile your software, this page provides some tips and
-guidelines for doing so.
 
-## Building statically linked applications
+Due to the distributed nature of the Open Science Grid, you will always need to 
+ensure that your jobs have access to the software that will be executed. This guide provides 
+useful information and examples for compiling and using your software in OSG Connect. 
 
-When an application is statically compiled, the majority  of the libraries that 
-the application uses is compiled and packaged with the application binaries.
-This signficantly reduces the things that the application depends on, allowing
-the application to run on a much larger proportion of systems.
+> *What is compiling?*
+> The process of compiling converts ASCII (i.e. human readable) code into binary, 
+> machine readable code that will execute the steps of the program. 
 
-You can compile code using gcc using the `-static` flag when compiling.  If you
-are building an application that uses `configure`, then using the
-`--enable-static` option should create a statically linked application.
-Otherwise, setting `LD_FLAGS` in the environment to `--enable-static` 
-(e.g. `export LD_FLAGS="--enable-static"`) make generate statically linked
-binaries.
+## Get software source code
 
-## Building dyanmically linked applications
+The first step to compiling your software is to locate and download the source 
+code for your software, being sure to select the version that you want. Source code 
+will often be made available as a compressed tar archive which will need to be 
+extracted for before compilation.
 
-GCC and ld dynamically link applications by default so you probably will not need
-to do anything special to create a dynamically linked application.  However, you
-should read the following sections in order to generate binaries that will function 
-correctly.
+You should also carefully review the installation instructions provided by the 
+software developers. The installation instructions should include important 
+information regarding various options for configuring and performing the compilation. 
+Also carefully note any system dependencies (other software and libraries) that are 
+required for your software.
 
-## Compilation Server
+## Select the appropriate compiler and compilation options
 
-Regardless of whether you statically or dynamically compile your application,
-you should compile your application on your assigned login node.  This will ensure
+A compiler is a program that is used to peform source code compilation. The GNU Compiler 
+Collection (GCC) is a common, open source collection of compilers with support for C, C++, 
+fotran, and other languages, and includes important libraries for supporting your compilation 
+and sometimes software executation. Your software compilation may require certain versions 
+of compilers which should be noted in the installtion instructions or system dependencies 
+documention. Currently the login nodes have `GCC 4.8.5` as the default version, but ...
+
+CMake is a commonly used compilation platform. Your software may have dependencies for 
+specific `make` versions. Currently the login nodes have two versions of CMake, `3.12.3` 
+and `3.13.0` available as [modules](https://support.opensciencegrid.org/support/solutions/articles/12000048518). 
+
+Most source code is written to write the compiled binaries to a default path.
+
+### Static versus dynamic linking during compilation
+
+Binary code often depends on additional information (i.e. instructions) from other software, 
+known as libraries, for proper execution. The default behavior when compiling, is for the 
+final binary to be "dynamically linked" to libraries that it depends on, such that when 
+the binary is executed, it will look for these library files on the system that it is 
+running on. Thus a copy of the appropriate library files will need to be available to your 
+software whenever it runs. OSG Connect users can transfer copies of libraries necessary 
+libraries with their jobs to manage such dependencies may not be supported by the node 
+that your jobs run on.
+
+However, the option exists to "statically link" the library dependencies of your software 
+binary. By statically linking libraries during compilation, the library coded will be 
+directly packaged with your software binary. This signficantly reduces the execute node 
+system dependencies for running your software and can potentially allow you jobs to run
+on a greater proportion of OSG nodes.
+
+To statically link libraries during compilation, use the `-static` flag when running `gcc`, 
+use `--enable-static` when running a `configure` script, or set your `LD_FLAGS` 
+environment variable to `--enable-static` (e.g. `export LD_FLAGS="--enable-static"`).
+
+### Get access to libraries needed for your software
+
+As described above, your software may require additional software, known as libraries, for 
+compilation and execution. For greatest portability of your software, we recommend installing 
+the libraries needed for your software and transferring a copy of the libraries along with 
+your subsequent jobs. When using libraries that you have installed yourself, you will likely 
+need to add these libraries to your `LIBRARY_PATH` environment variable before compiling 
+your software. There may also be additional environment variables that will need to be 
+defined or modified for software compilation, this information should be provided 
+in the installtion instructions of your software. For any libraries added to `LIBRARY_PATH` 
+before software compilation, you'll likely also need to add these same libraries to 
+your `LD_LIBRARY_PATH` as a step in your job's executable bash script before executing 
+your software.
+
+The Octopus complilation example below includes an example of installing 
+and using user-installed libraries for software compilation and execution.
+
+The [distributed environment modules system](https://support.opensciencegrid.org/support/solutions/articles/12000048518) 
+available on OSG Connect also provides several commonly used software libraries 
+(lapack, atlas, hdf5, netcdf, etc.) that can be used for your software compilation and 
+execution. The appropriate modules should be loaded before performing your software 
+compilation. The process of loading a module will modify all appropriate 
+environment variables (e.g. `CPATH` and `LIBRARY_PATH`) for you. If you do use modules 
+from the modules system, you will need to modify your job scripts to load the appropriate 
+modules before running you software.
+
+## Perform your compilation
+
+Software compilation is easiest to perform interactively, and OSG Connect users are 
+welcome to compile software directly on their assigned login node. This will ensure
 that your application is built on an environment that is similar to the majority
-of the compute nodes on OSG.  In addition, you will need to add the following
-require to your HTCondor submit file: `(OpSysAndVer =?= "SL7") || (OpSysAndVer
-=?= "RHEL7") || (OpSysAndVer =?= "Centos6")` to make sure that your binaries run 
-systems that have compatible linux distributions.
+of the compute nodes on OSG. Because OSG Connect login nodes currently use the 
+Red Hat Enterprise Linux 7 operating system, your software will, generally, only be 
+compatible for execution on RHEL 7 or similar operating systems. You can use the 
+`requirements` statement of your HTCondor submit file to direct your jobs to execute 
+nodes with specific operating systems, for instance:
 
-## Libraries
+	requirements = (OpSysAndVer =?= "SL7") || (OpSysAndVer=?= "RHEL7") || (OpSysAndVer =?= "Centos7")
 
-The distributed environment modules system provides several commonly used
-scientific libraries (lapack, atlas, hdf5, netcdf, etc.) that your application
-may need to link to.  In order to link against a library provided by the
-module system, just load the appropriate module (e.g. `hdf5/1.8.12`).  Doing so
-will set the `CPATH` and `LIBRARY_PATH` so that gcc will be able to find the
-includes and link files for that library.  If your build system does not pick up
-the appropriate you can look at the `CPATH` and `LIBRARY_PATH` variables to find
-the paths used and incorporate that into your build process or you can contact
-user support for assistance.
+Software installation typically includes three steps: 1.) configuration, 2.) compilation, and 3.) 
+"installation" which places the compiled code in specific location. In most cases install instructions, 
+these steps will be achieved with the following commands:
 
-Finally, if you do use modules from the modules system, you will need to modify
-your job scripts to load the appropriate modules before running you application.
+	./configure
+	make
+	make install
 
-## Assistance
+Most software is written to install to a default location, however your OSG Connect 
+account is not authorized to write to these default system locations. Instead, you will want to 
+create a folder for your software installation in your `home` directory use an option in the 
+configuration step that will install the software to this folder:
+
+	./configure --prefix=/home/username/path
+
+where `username` should be replaced with your OSG Connect username and `path` replaced with the 
+path to the directory you created for your software installation.
+
+## Get Additional Assistance
 If you have questions or need assistance, please contact <support@osgconnect.net>.
-

--- a/start/software/compiling-applications.md
+++ b/start/software/compiling-applications.md
@@ -55,9 +55,8 @@ execute node that your jobs run on.
 
 However, the option exists to "statically link" the library dependencies of your software. 
 By statically linking libraries during compilation, the library code will be 
-directly packaged with your software binary. By statically linking libraries during 
-compilation, the library code will always be available to your software and will help 
-your software to run on more execute nodes.
+directly packaged with your software binary meaning the libraries will always be 
+available to your software which your software to run on more execute nodes.
 
 To statically link libraries during compilation, use the `-static` flag when running `gcc`, 
 use `--enable-static` when running a `configure` script, or set your `LD_FLAGS` 

--- a/start/software/example-compilation.md
+++ b/start/software/example-compilation.md
@@ -165,7 +165,7 @@ for organizing all compiled software in the `home` directory:
 > As a best practice, always include the version name of your software in the directory name.
 
 Next we'll change to the Samtools source code direcory that was created in 
-[Step 1](#step-1-.-acquire-samtools-source-code). You should see the `INSTALL` and `README` files 
+[Step 1](#step-1-acquire-samtools-source-code). You should see the `INSTALL` and `README` files 
 as well as a file called `configure`.
 
 The first command we will run is `./configure` - this step will execute the configure script 

--- a/start/software/example-compilation.md
+++ b/start/software/example-compilation.md
@@ -13,8 +13,9 @@ software for working with aligned sequencing data. However, the steps described 
 example are applicable to many other software. For a general introduction to software 
 compilation in OSG Connect, please see [Compiling Software for OSG Connect](https://support.opensciencegrid.org/support/solutions/articles/5000652099).
 
-Specifically, this guide provides two examples of compiling Samtools, one without CRAM file 
-support and one with CRAM file support. *Why two examples?* Currently, to install Samtools 
+Specifically, this guide provides two examples of compiling Samtools, [one without CRAM file 
+support](#compile-samtools-without-cram-support) and [one with CRAM file support](#compile-samtools-with-cram-support). 
+*Why two examples?* Currently, to install Samtools 
 with CRAM support requires additional dependencies (aka libraries) that will also need to be 
 installed and most Samtools users are only working with BAM files which does not require CRAM 
 support.

--- a/start/software/example-compilation.md
+++ b/start/software/example-compilation.md
@@ -263,7 +263,7 @@ to "untar" the Samtools and add this software to the `PATH` enviroment variable:
 	tar -xzf samtools-1.10.tar.gz
 
 	# modify environment variables 
-	export PATH=$_CONDOR_SCRATCH_DIR/samtools-1.10/bin:$_CONDOR_SCRATCH_DIR/xz-5.2.5/bin:$PATH
+	export PATH=$_CONDOR_SCRATCH_DIR/samtools-1.10/bin:$PATH
 	
 	# run samtools commands
 	...

--- a/start/software/example-compilation.md
+++ b/start/software/example-compilation.md
@@ -105,7 +105,7 @@ for installing Samtools and HTSlib (which is itself a dependency of Samtools):
 Some dependencies are needed to support certain features from Samtools (such as `tview` and 
 CRAM compression). You will not need `tview` as this is intended for interactive work which is 
 not currently supported in OSG Connect. For this specific compilation example, we will disable 
-both `tview` and CRAM support - see [below](#install-samtools-with-cram-support) for our 
+both `tview` and CRAM support - see [below](#compile-samtools-with-cram-support) for our 
 compilation example that will provide CRAM file support. 
 
 Following the suggestion in the Samtools `INSTALL` file, we can view the HTSlib `INSTALL` 
@@ -272,7 +272,7 @@ to "untar" the Samtools and add this software to the `PATH` enviroment variable:
 This example includes steps to install and use a library and to use a module, 
 which are both currently needed for compiling Samtools with CRAM support. 
 
-The steps following steps in this example assume that you have performed 
+The steps in this example assume that you have performed 
 [Step 1](#step-1-acquire-samtools-source-code) and 
 [Step 2](#step-2-read-through-installation-instructions) in the above example for 
 compiling Samtools without CRAM support.
@@ -285,17 +285,17 @@ libzlma are required for CRAM support. We can check our system for these librari
 	[user@login ~]$ ls /usr/lib* | grep libz
 	[user@login ~]$ ls /usr/lib* | grep libbz2
 
-which will reveal that both sets of libraries are available on the login node which 
-means we can moved on to performing our compilation with CRAM support. **However** 
-if we were to attempt Samtools installation with CRAM support right now, 
+which will reveal that both sets of libraries are available on the login. **However** 
+if we were to attempt Samtools installation with CRAM support right now 
 we would find that this results in an error when performing the `configure` step.
 
 *If the libraries are present, why do we get this error?* This error is due to 
 differences between types of library files. For example, running 
-`ls /usr/lib\* | grep libbz2` will return two matches, `libbz2.so.1` and `libbz2.so.1.0.6`. 
-But running `ls /usr/lib\* | grep liblz` will return four matches including three 
-`.so` and one `.a` match. Our Samtools compilation specifically requires 
-the `.a` type of library file for both `libbz2` and `liblzma` and is why compilation 
+`ls /usr/lib* | grep libbz2` will return two matches, `libbz2.so.1` and `libbz2.so.1.0.6`. 
+But running `ls /usr/lib* | grep liblz` will return four matches including three 
+`.so` and one `.a` files. Our Samtools compilation specifically requires 
+the `.a` type of library file for both `libbz2` and `liblzma` and the absence of 
+this type of library file in `/usr/lib64` is why compilation 
 will fail without additional steps.
 
 Luckily for us, bzip2 version 1.0.6 is available as a module and this module 
@@ -310,7 +310,7 @@ will be to install `liblzma`.
 To compile Samtools with CRAM support requires that we first compile 
 `liblzma`. Following the same approach as we did for Samtools, first we 
 acquire a copy of the the latest liblzma source code, then review the installation instructions. 
-From our online search we will find that XZ Utils has replaced LZMA Utils and that liblzma 
+From our online search we will that `liblzma` 
 is availble from the XZ Utils library package.
 
 	[user@login ~]$ wget https://tukaani.org/xz/xz-5.2.5.tar.gz
@@ -333,7 +333,7 @@ Perform the XZ Utils compilation:
 
 Success!
 
-Lastly we need to set a some environment variable so that Samtools knows where to 
+Lastly we need to set some environment variables so that Samtools knows where to 
 find this library:
 
 	[user@login xz-5.2.5]$ export PATH=$HOME/my-software/xz-5.2.5/bin:$PATH
@@ -367,8 +367,8 @@ for organizing all compiled software in the `home` directory:
 
 > As a best practice, always include the version name of your software in the directory name.
 
-Change our directories to the Samtools source code direcory that was created in 
-[Step 1](#step-1-.-acquire-samtools-source-code). You should see the `INSTALL` and `README` files 
+Next, we will change our directory to the Samtools source code direcory that was created in 
+[Step 1](#step-1-acquire-samtools-source-code). You should see the `INSTALL` and `README` files 
 as well as a file called `configure`.
 
 The first command we will run is `./configure` - this file is a script that allows us 
@@ -387,7 +387,7 @@ Next run the final two commands:
 
 Once `make install` has finished running, the compilation is complete. We can 
 also confirm this by looking at the content of `~/my-software/samtools-1.10/` where 
-we has Samtools installed:
+we had Samtools installed:
 
 	[user@login samtools-1.10]$ cd ~
 	[user@login ~]$ ls -F my-software/samtools-1.10/
@@ -404,13 +404,12 @@ which will return the Samtools `view` usage statement.
 ### Step 6. Make our software portable
 
 Our subsequent job submissions on OSG Connect will need a copy of our software. For 
-convenience, we recommend converting your software directory to a tar archive, this will 
-be particularly useful if our jobs will use more than one "tool" from Samtools. 
+convenience, we recommend converting your software directory to a tar archive. 
 First move to `my-software/`, then create the tar archive:
 	
 	[user@login ~]$ mv my-software/
 	[user@login my-software]$ tar -czf samtools-1.10.tar.gz samtools-1.10/
-	[user@login my-software]$ ls -lh samtools-1.10.tar.gz
+	[user@login my-software]$ ls samtools-1.10*
 	samtools-1.10/ samtools-1.10.tar.gz
 	[user@login my-software]$ du -h samtools-1.10.tar.gz
 	2.0M	samtools-1.10.tar.gz
@@ -420,8 +419,10 @@ important for determine the appropriate method that we should use for transferri
 this file along with our subsequent jobs. To learn more, please see 
 [Introduction to Data Management on OSG Connect](https://support.opensciencegrid.org/support/solutions/articles/12000002985).
 
+Follow the these same steps for creating a tar archive of the xz-5.2.5 library as well. 
+
 To clean up and clear out space in your home directory, we recommend deleting the Samtools source 
-code directory and the installation directory.
+code directory.
 
 ### Step 7. Use Samtools in our jobs
 
@@ -451,7 +452,7 @@ for a job that will use Samtools with a CRAM file named `my-sample.cram` which i
 
 The above submit file will transfer a complete copy of the Samtools tar archive 
 created in [Step 6](#step-6-make-our-software-portable) as well as a copy of XZ Utils installation from 
-[Step 3](#step-3-compile-liblzma) from which a tar archive was also created. This submit file 
+[Step 3](#step-3-compile-liblzma). This submit file 
 also includes two important `requirements` which tell HTCondor to run our job on 
 execute nodes running Red Hat Linux version 7 operating system and which has 
 access to OSG Connect software modules.

--- a/start/software/example-compilation.md
+++ b/start/software/example-compilation.md
@@ -22,12 +22,6 @@ support.
 *Do I need CRAM support for my work?* CRAM is an alternative compressed sequence alignment 
 file format to BAM. Learn more at [https://www.sanger.ac.uk/tool/cram/](https://www.sanger.ac.uk/tool/cram/).
 
-## Get Organized
-
-How you organize the content of your `home` directory is entirely up to you, but there are some 
-general best practices that we recommend. First, and foremost, use directories to organize your 
-`home` content. Second, install your software to a separate location
-
 ## Compile Samtools Without CRAM Support
 
 ### Step 1. Acquire Samtools source code
@@ -38,16 +32,16 @@ development code is also available via GitHub at [https://github.com/samtools/sa
 > "\[Samtools\] uses HTSlib internally \[and\] these source packages contain their own copies of htslib"
 
 What this means is 1.) HTSlib is a dependency of Samtools and 2.) the HTSlib source code is included 
-in along with the Samtools source code.
+with the Samtools source code.
 
 Either download the Samtools source code to your computer and upload to the your login node, or
-right-click on the Samtools source code link and copy the link location. Login in to your OSG Connect login 
+right-click on the Samtools source code link and copy the link location. Login in to your OSG Connect login node  
 and use `wget` to download the source code directly and extract the tarball:
 
 	[user@login ~]$ wget https://github.com/samtools/samtools/releases/download/1.10/samtools-1.10.tar.bz2
 	[user@login ~]$ tar -xjf samtools-1.10.tar.bz2
 
-The above two commands will create directory named `samtools-1.10` which contains all the code 
+The above two commands will create a directory named `samtools-1.10` which contains all the code 
 and instructions needed for compiling Samtools and HTSlib. Take a moment to look at the content available 
 in this new directory.
 
@@ -115,7 +109,7 @@ both `tview` and CRAM support - see [below](#install-samtools-with-cram-support)
 compilation example that will provide CRAM file support. 
 
 Following the suggestion in the Samtools `INSTALL` file, we can view the HTSlib `INSTALL` 
-file at `samtools-`1.10/htslib-1.10/INSTALL`. Here we will find the necessary 
+file at `samtools-1.10/htslib-1.10/INSTALL`. Here we will find the necessary 
 information for disabling bzip2 and liblzma dependencies:
 
 	--disable-bz2
@@ -128,15 +122,15 @@ information for disabling bzip2 and liblzma dependencies:
 	    by default.  It can be disabled with --disable-lzma, but be aware
 	    that not all CRAM files may be possible to decode. 
 
-These are examples of two flags that will need to be used when performing our installation.
+These are two flags that will need to be used when performing our installation.
 
-To determine what libraries are available on your OSG Connect login node, you can look at `/usr/lib` 
+To determine what libraries are available on our OSG Connect login node, we can look at `/usr/lib` 
 and `/usr/lib64` for the various Samtools library dependencies, for example:
 
 	[user@login ~]$ ls /usr/lib* | grep libcurl
 	[user@login ~]$ ls /usr/lib* | grep htslib
 
-Although we will find hits for libcurl, we will not find any htslib files meaning that 
+Although we will find matches for `libcurl`, we will not find any `htslib` files meaning that 
 HTSlib is not currently installed on the login node, nor is it currently available 
 as a module. This means that HTSlib will also need to be compiled. Luckly, the Samtools 
 developers have conveniently included the HTSlib source code with the Samtools source code 
@@ -148,21 +142,21 @@ Samtools `INSTALL` file, is the following:
 	    you will have to choose one via this option.
 
 This mean that we don't have to do anything extra to get HTSlib installed because 
-the Samtools installation will by default do it for us.
+the Samtools installation will do it by default.
 
 > When performing your compilation, if your compiler is unable to locate the necessary 
 > libraries, or if newer versions of libraries are needed, it will result in an error - this 
-> makes for an alternative method for determining whether your system has the appropriate 
+> makes for an alternative method of determining whether your system has the appropriate 
 > libraries for your software and more often than not, installation by trial and error is 
-> a common approach many people take. However, taking a little bit of time before hand 
-> and looking for library files can save you time and frustration.
+> a common approach. However, taking a little bit of time before hand 
+> and looking for library files can save you time and frustration during software compilation.
 
 ### Step 3. Perform Samtools compilation
 
 We now have all of the information needed to start our compilation of Samtools without CRAM support.
 
 First, we will create a new directory in our `home` directory that will store the 
-Samtools compiled software. The example here will use a common directory, called `my-software`, 
+Samtools compiled software. The example here will use a directory, called `my-software`, 
 for organizing all compiled software in the `home` directory:
 
 	[user@login ~]$ mkdir $HOME/my-software
@@ -170,19 +164,19 @@ for organizing all compiled software in the `home` directory:
 
 > As a best practice, always include the version name of your software in the directory name.
 
-Change our directories to the Samtools source code direcory that was created in 
+Next we'll change to the Samtools source code direcory that was created in 
 [Step 1](#step-1-.-acquire-samtools-source-code). You should see the `INSTALL` and `README` files 
 as well as a file called `configure`.
 
-The first command we will run is `./configure` - this file is a script that allows us 
-to modify various details about our Samtools installation and we will be executing `configure` 
+The first command we will run is `./configure` - this step will execute the configure script 
+and allows us to modify various details about our Samtools installation. We will be executing `configure` 
 with several flags:
 
 	[user@login samtools-1.10]$ ./configure --prefix=$HOME/my-software/samtools-1.10 --disable-bz2 --disable-lzma --without-curses
 
 Here we used `--prefix` to specify where we would like the final Samtools software 
-to be installed, `--disable-bz2` and `--disable-lzma` to disable lzma 
-and bzip2 dependencies for CRAM, and `--without-curses` to disable `tview` support.
+to be installed, `--disable-bz2` and `--disable-lzma` to disable `lzma` 
+and `bzip2` dependencies for CRAM, and `--without-curses` to disable `tview` support.
 
 Next run the final two commands:
 
@@ -191,7 +185,7 @@ Next run the final two commands:
 
 Once `make install` has finished running, the compilation is complete. We can 
 also confirm this by looking at the content of `~/my-software/samtools-1.10/` where 
-we has Samtools installed:
+we had Samtools installed:
 
 	[user@login samtools-1.10]$ cd ~
 	[user@login ~]$ ls -F my-software/samtools-1.10/
@@ -208,13 +202,12 @@ which will return the Samtools `view` usage statement.
 ### Step 4. Make our software portable
 
 Our subsequent job submissions on OSG Connect will need a copy of our software. For 
-convenience, we recommend converting your software directory to a tar archive, this will 
-be particularly useful if our jobs will use more than one "tool" from Samtools. 
+convenience, we recommend converting your software directory to a tar archive. 
 First move to `my-software/`, then create the tar archive:
 
 	[user@login ~]$ mv my-software/
 	[user@login my-software]$ tar -czf samtools-1.10.tar.gz samtools-1.10/
-	[user@login my-software]$ ls -lh samtools-1.10.tar.gz
+	[user@login my-software]$ ls samtools-1.10*
 	samtools-1.10/ samtools-1.10.tar.gz
 	[user@login my-software]$ du -h samtools-1.10.tar.gz
 	2.0M	samtools-1.10.tar.gz
@@ -225,14 +218,12 @@ this file along with our subsequent jobs. To learn more, please see
 [Introduction to Data Management on OSG Connect](https://support.opensciencegrid.org/support/solutions/articles/12000002985).
 
 To clean up and clear out space in your home directory, we recommend deleting the Samtools source 
-code directory and the installation directory.
+code directory.
 
 ### Step 5. Use Samtools in our jobs
 
-Now that Samtools has been compiled we can submit jobs that use this software. For Samtools 
-with CRAM we will also need to bring along a copy of XZ Utils (which includes the `liblzma` library) 
-and ensure that our jobs have access to the `bzip2 1.0.6` module. Below is an example submit file 
-for a job that will use Samtools with a CRAM file named `my-sample.bam` which is <100MB in size:
+Now that Samtools has been compiled we can submit jobs that use this software. Below is an example submit file 
+for a job that will use Samtools with a BAM file named `my-sample.bam` which is <100MB in size:
 
 	#samtools.sub
 	log = samtools.$(Cluster).log
@@ -262,7 +253,7 @@ execute nodes running Red Hat Linux version 7 operating system.
 > above example. Always run tests to determine the appropriate requests for your jobs.
 
 Some additional steps are then needed in the executable bash script used by this job 
-to "untar" the Samtools and (optionally) modify the `PATH` enviroment variable:
+to "untar" the Samtools and add this software to the `PATH` enviroment variable:
 
 	#!/bin/bash
 	# samtools.sh

--- a/start/software/example-compilation.md
+++ b/start/software/example-compilation.md
@@ -35,7 +35,7 @@ development code is also available via GitHub at [https://github.com/samtools/sa
 What this means is 1.) HTSlib is a dependency of Samtools and 2.) the HTSlib source code is included 
 with the Samtools source code.
 
-Either download the Samtools source code to your computer and upload to the your login node, or
+Either download the Samtools source code to your computer and upload to your login node, or
 right-click on the Samtools source code link and copy the link location. Login in to your OSG Connect login node  
 and use `wget` to download the source code directly and extract the tarball:
 
@@ -481,5 +481,4 @@ to "untar" the Samtools and XZ Util tar archives, modify the `PATH` and
 
 	# run samtools commands
 	...
-
 

--- a/start/software/example-compilation.md
+++ b/start/software/example-compilation.md
@@ -13,47 +13,142 @@ software for working with aligned sequencing data. However, the steps described 
 example are applicable to many other software. For a general introduction to software 
 compilation in OSG Connect, please see [Compiling Software for OSG Connect](https://support.opensciencegrid.org/support/solutions/articles/5000652099).
 
-## Compile Samtools
+Specifically, this guide provides two examples of compiling Samtools, one without CRAM file 
+support and one with CRAM file support. *Why two examples?* Currently, to install Samtools 
+with CRAM support requires additional dependencies (aka libraries) that will also need to be 
+installed and most Samtools users are only working with BAM files which does not require CRAM 
+support.
+
+*Do I need CRAM support for my work?* CRAM is an alternative compressed sequence alignment 
+file format to BAM. Learn more at [https://www.sanger.ac.uk/tool/cram/](https://www.sanger.ac.uk/tool/cram/).
+
+## Get Organized
+
+How you organize the content of your `home` directory is entirely up to you, but there are some 
+general best practices that we recommend. First, and foremost, use directories to organize your 
+`home` content. Second, install your software to a separate location
+
+## Compile Samtools Without CRAM Support
 
 ### Step 1. Acquire Samtools source code
 
 Samtools source code is available at [http://www.htslib.org/download/](http://www.htslib.org/download/). The 
-development code is also available via GitHub at [https://github.com/samtools/samtools](https://github.com/samtools/samtools).
+development code is also available via GitHub at [https://github.com/samtools/samtools](https://github.com/samtools/samtools). On the download page is some important information to make note of:
 
-Either download the Samtools source code to your co
-Right-click on the Samtools source code link and copy the link location. Login in to your OSG Connect login 
+> "\[Samtools\] uses HTSlib internally \[and\] these source packages contain their own copies of htslib"
+
+What this means is 1.) HTSlib is a dependency of Samtools and 2.) the HTSlib source code is included 
+in along with the Samtools source code.
+
+Either download the Samtools source code to your computer and upload to the your login node, or
+right-click on the Samtools source code link and copy the link location. Login in to your OSG Connect login 
 and use `wget` to download the source code directly and extract the tarball:
 
-	wget https://github.com/samtools/samtools/releases/download/1.10/samtools-1.10.tar.bz2
-	tar -xjf samtools-1.10.tar.bz2
+	[user@login ~]$ wget https://github.com/samtools/samtools/releases/download/1.10/samtools-1.10.tar.bz2
+	[user@login ~]$ tar -xjf samtools-1.10.tar.bz2
 
 The above two commands will create directory named `samtools-1.10` which contains all the code 
-needed for compiling Samtools.
+and instructions needed for compiling Samtools and HTSlib. Take a moment to look at the content available 
+in this new directory.
 
 ### Step 2. Read through installation instructions
 
-The HTSlib website page where the Samtools source code is hosted provides basic installation instructions 
-and refers to `INSTALL` for more information. Source code directories will always include a `README` 
-file with important information including where to get detailed installation instructions. 
+*What steps need to be performed for our compilation? What system dependencies exist for our 
+software?* Answers to these questions, and other important information, should be available 
+in the installation instructions for your software which will be available online and/or 
+included in the source code.
 
-`cd` to samtools-1.10 and read through `README` and `INSTALL`. As described in `INSTALL`, there are 
-a number of required and optional system dependencies for installing Samtools. Some dependencies are 
-needed to support certain features from Samtools (such as `tview` and CRAM). You will not need `tview`
-as this is intended for interactive work which is not currently supported in OSG Connect. These 
-installation instructions include additional flags that can be used to disable certain software 
-features that remove the need for some of these dependencies.
+The HTSlib website where the Samtools source code is hosted provides basic installation instructions 
+and refers users to `INSTALL` (which is a plain text file that can be found in `samtools-1.10/`) for 
+more information. You will also see a `README` file in the source code directory which will provide 
+important information. `README` files will always be included with your source code and we 
+recommend reviewing before compiling software. There is also a `README` and `INSTALL` file available 
+for HTSlib in the source code directory `samtools-1.10/htslib-1.10/`.
+
+`cd` to samtools-1.10 and read through `README` and `INSTALL`. As described in `INSTALL`, 
+the Samtools installation will follow the common `configure`, `make`, `make install` process:
+
+	Basic Installation
+	==================
+	
+	To build and install Samtools, 'cd' to the samtools-1.x directory containing
+	the package's source and type the following commands:
+	
+	    ./configure
+	    make
+	    make install
+	
+	The './configure' command checks your build environment and allows various
+	optional functionality to be enabled (see Configuration below). 
+
+Also described in `INSTALL` are a number of required and optional system dependencies 
+for installing Samtools and HTSlib (which is itself a dependency of Samtools):
+
+	System Requirements
+	===================
+	
+	Samtools and HTSlib depend on the following libraries:
+	
+	  Samtools:
+	    zlib       <http://zlib.net>
+	    curses or GNU ncurses (optional, for the 'tview' command)
+	               <http://www.gnu.org/software/ncurses/>
+	
+	  HTSlib:
+	    zlib       <http://zlib.net>
+	    libbz2     <http://bzip.org/>
+	    liblzma    <http://tukaani.org/xz/>
+	    libcurl    <https://curl.haxx.se/>
+	               (optional but strongly recommended, for network access)
+	    libcrypto  <https://www.openssl.org/>
+	               (optional, for Amazon S3 support; not needed on MacOS)
+	
+	...
+	
+	The bzip2 and liblzma dependencies can be removed if full CRAM support
+	is not needed - see HTSlib's INSTALL file for details.
+
+Some dependencies are needed to support certain features from Samtools (such as `tview` and 
+CRAM compression). You will not need `tview` as this is intended for interactive work which is 
+not currently supported in OSG Connect. For this specific compilation example, we will disable 
+both `tview` and CRAM support - see [below](#install-samtools-with-cram-support) for our 
+compilation example that will provide CRAM file support. 
+
+Following the suggestion in the Samtools `INSTALL` file, we can view the HTSlib `INSTALL` 
+file at `samtools-`1.10/htslib-1.10/INSTALL`. Here we will find the necessary 
+information for disabling bzip2 and liblzma dependencies:
+
+	--disable-bz2
+	    Bzip2 is an optional compression codec format for CRAM, included
+	    in HTSlib by default.  It can be disabled with --disable-bz2, but
+	    be aware that not all CRAM files may be possible to decode.
+
+	--disable-lzma
+	    LZMA is an optional compression codec for CRAM, included in HTSlib
+	    by default.  It can be disabled with --disable-lzma, but be aware
+	    that not all CRAM files may be possible to decode. 
+
+These are examples of two flags that will need to be used when performing our installation.
 
 To determine what libraries are available on your OSG Connect login node, you can look at `/usr/lib` 
 and `/usr/lib64` for the various Samtools library dependencies, for example:
 
-	ls /usr/lib64 | grep libcurl
-	ls /usr/lib64 | grep libz
-	ls /usr/lib64 | grep libbz2
+	[user@login ~]$ ls /usr/lib* | grep libcurl
+	[user@login ~]$ ls /usr/lib* | grep htslib
 
-will return with several hits, confirming that specific versions of these libraries are 
-already installed on the login node. However, the HTSlib library is not currently 
-available on the login node, nor is is currently available as a module, and thus HTSlib 
-will need to additionally be compiled before proceeding with compiling samtools.
+Although we will find hits for libcurl, we will not find any htslib files meaning that 
+HTSlib is not currently installed on the login node, nor is it currently available 
+as a module. This means that HTSlib will also need to be compiled. Luckly, the Samtools 
+developers have conveniently included the HTSlib source code with the Samtools source code 
+and have made it possible to compile both Samtools and HTSlib at the same time. From the 
+Samtools `INSTALL` file, is the following: 
+
+	    By default, configure looks for an HTSlib source tree within or alongside
+	    the samtools source directory; if there are several likely candidates,
+	    you will have to choose one via this option.
+
+This mean that we don't have to do anything extra to get HTSlib installed because 
+the Samtools installation will by default do it for us.
 
 > When performing your compilation, if your compiler is unable to locate the necessary 
 > libraries, or if newer versions of libraries are needed, it will result in an error - this 
@@ -61,6 +156,76 @@ will need to additionally be compiled before proceeding with compiling samtools.
 > libraries for your software and more often than not, installation by trial and error is 
 > a common approach many people take. However, taking a little bit of time before hand 
 > and looking for library files can save you time and frustration.
+
+### Step 3. Perform Samtools Compilation
+
+We now have all of the information needed to start our compilation of Samtools without CRAM support.
+
+First, we will create a new directory in our`home` directory that will store the 
+Samtools compiled software. The example here will use a common directory, called `my-software`, 
+for organizing all compiled software in the `home` directory:
+
+	[user@login ~]$ mkdir my-software
+	[user@login ~]$ mkdir my-software/samtools-1.10
+
+> As a best practice, always include the version name of your software in the directory name.
+
+Change our directories to the Samtools source code direcory that was created in 
+[Step 1](#step-1-.-acquire-samtools-source-code). You should see the `INSTALL` and `README` files 
+as well as a file called `configure`.
+
+The first command we will run is `./configure` - this file is a script that allows us 
+to modify various details about our Samtools installation and we will be executing `configure` 
+with several flags:
+
+	[user@login samtools-1.10]$ ./configure --prefix=$HOME/my-software/samtools-1.10 --disable-bz2 --disable-lzma --without-curses
+
+Here we used `--prefix` to specify where we would like the final Samtools software 
+to be installed, `--disable-bz2` and `--disable-lzma` to disable lzma 
+and bzip2 dependencies for CRAM, and `--without-curses` to disable `tview` support.
+
+Next run the final two commands:
+
+	[user@login samtools-1.10]$ make
+	[user@login samtools-1.10]$ make install
+
+Once `make install` has finished running, the compilation is complete. We can 
+also confirm this by looking at the content of `~/my-software/samtools-1.10/` where 
+we has Samtools installed:
+
+	[user@login samtools-1.10]$ cd ~
+	[user@login ~]$ ls -F my-software/samtools-1.10/
+	bin/ share/
+
+There will be two directories present in `my-software/samtools-1.10`, one named `bin` and 
+another named `share`. The Samtools executable will be located in `bin` and we can give 
+it a quick test to make sure it runs as expected:
+
+	[user@login ~]$ ./my-software/samtools-1.10/bin/samtools view
+
+which will return the Samtools `view` usage statement.
+
+### Step 4. Make Your Software Portable
+
+Our subsequent job submissions on OSG Connect will need a copy of our software. For 
+convenience, we recommend converting your software directory to a tar archive, this will 
+be particularly useful if our jobs will use more than one "tool" from Samtools. 
+First move to `my-software/`, then create the tar archive:
+
+	[user@login ~]$ mv my-software/
+	[user@login my-software]$ tar -czf samtools-1.10.tar.gz samtools-1.10/
+	[user@login my-software]$ ls -lh samtools-1.10.tar.gz
+	samtools-1.10/ samtools-1.10.tar.gz
+	[user@login my-software]$ du -h samtools-1.10.tar.gz
+	2.0M	samtools-1.10.tar.gz
+
+The last command in the above example returns the size of our tar archive. This is 
+important for determine the appropriate method that we should use for transferring 
+this file in our subsequent jobs. To learn more, please see 
+[Introduction to Data Management on OSG Connect](https://support.opensciencegrid.org/support/solutions/articles/12000002985).
+
+To clean up and clear out space in your home directory, we recommend deleting the Samtools source 
+code directory and the installation directory.
 
 ### Step 3. Install HTSlib
 
@@ -117,3 +282,5 @@ Samtools.
  
 	make
 	make
+	ls /usr/lib* | grep libz
+	ls /usr/lib* | grep libbz2

--- a/start/software/example-compilation.md
+++ b/start/software/example-compilation.md
@@ -1,0 +1,70 @@
+[title]: - "Example Software Compilation"
+
+# Example of Compilng Software For Use In OSG Connect
+
+## Introduction
+
+Due to the distributed nature of the Open Science Grid, you will always need to 
+ensure that your jobs have access to the software that will be executed. This guide provides 
+a detailed example of compiling software for use in OSG Connect. 
+
+For this example, we will be compiling Samtools which is a very common bioinformatics 
+software for working with aligned sequencing data. However, the steps described in this 
+example are applicable to many other software. For a general introduction to software 
+compilation in OSG Connect, please see [Compiling Software for OSG Connect](https://support.opensciencegrid.org/support/solutions/articles/5000652099).
+
+## Compile Samtools
+
+### Step 1. Acquire Samtools source code
+
+Samtools source code is available at [http://www.htslib.org/download/](http://www.htslib.org/download/). The 
+development code is also available via GitHub at [https://github.com/samtools/samtools](https://github.com/samtools/samtools).
+
+Either download the Samtools source code to your co
+Right-click on the Samtools source code link and copy the link location. Login in to your OSG Connect login 
+and use `wget` to download the source code directly and extract the tarball:
+
+	wget https://github.com/samtools/samtools/releases/download/1.10/samtools-1.10.tar.bz2
+	tar -xjf samtools-1.10.tar.bz2
+
+The above two commands will create directory named `samtools-1.10` which contains all the code 
+needed for compiling Samtools.
+
+### Step 2. Read through installation instructions
+
+The HTSlib website page where the Samtools source code is hosted provides basic installation instructions 
+and refers to `INSTALL` for more information. Source code directories will always include a `README` 
+file with important information including where to get detailed installation instructions. 
+
+`cd` to samtools-1.10 and read through `README` and `INSTALL`. As described in `INSTALL`, there are 
+a number of required and optional system dependencies for installing Samtools. Some dependencies are 
+needed to support certain features from Samtools (such as `tview` and CRAM). You will not need `tview`
+as this is intended for interactive work which is not currently supported in OSG Connect. These 
+installation instructions include additional flags that can be used to disable certain software 
+features that remove the need for some of these dependencies.
+
+To determine what libraries are available on your OSG Connect login node, you can look at `/usr/lib` 
+and `/usr/lib64` for the various Samtools library dependencies, for example:
+
+	ls /usr/lib64 | grep libcurl
+	ls /usr/lib64 | grep libz
+	ls /usr/lib64 | grep libbz2
+
+will return with several hits, confirming that specific versions of these libraries are 
+already installed on the login node. However, the HTSlib library is not currently 
+available on the login node, nor is is currently available as a module, and thus HTSlib 
+will need to additionally be compiled before proceeding with compiling samtools.
+
+> When performing your compilation, if your compiler is unable to locate the necessary 
+> libraries, or if newer versions of libraries are needed, it will result in an error - this 
+> makes for an alternative method for determining whether your system has the appropriate 
+> libraries for your software.
+
+### Step 3. Install HTSlib
+
+Follow steps 1 and 2 above for first compiling HTSlib.
+
+	wget https://github.com/samtools/htslib/releases/download/1.10.2/htslib-1.10.2.tar.bz2
+	tar -xjz htslib-1.10.2.tar.gz
+
+HTSlib has the same library dependencies as Samtools.

--- a/start/software/example-compilation.md
+++ b/start/software/example-compilation.md
@@ -58,13 +58,62 @@ will need to additionally be compiled before proceeding with compiling samtools.
 > When performing your compilation, if your compiler is unable to locate the necessary 
 > libraries, or if newer versions of libraries are needed, it will result in an error - this 
 > makes for an alternative method for determining whether your system has the appropriate 
-> libraries for your software.
+> libraries for your software and more often than not, installation by trial and error is 
+> a common approach many people take. However, taking a little bit of time before hand 
+> and looking for library files can save you time and frustration.
 
 ### Step 3. Install HTSlib
 
-Follow steps 1 and 2 above for first compiling HTSlib.
+Follow steps 1 (acquire soure code and untar) and 2 (review installation instructions) for HTSlib.
 
 	wget https://github.com/samtools/htslib/releases/download/1.10.2/htslib-1.10.2.tar.bz2
 	tar -xjz htslib-1.10.2.tar.gz
+	cd htslib-1.10.2/
+	less INSTALL
 
-HTSlib has the same library dependencies as Samtools.
+You will see that HTSlib has the same library dependencies as Samtools and from our initial examination of 
+available libraries on the submit node. Under "Basic Installation" you will see that 
+HTSLib follows the conventional `configure`, `make`, `make install` process described in 
+[Compiling Software for OSG Connect](https://support.opensciencegrid.org/support/solutions/articles/5000652099).
+
+To execute these three steps, first create a new directory in your home directoy where you 
+want the installation to be written to: 
+
+	mkdir $HOME/htslib-1.10.2-install
+
+> If you haven't already, next change directories to the HTSLib source code directory.
+
+Then run:
+
+	./configure --prefix=$HOME/htslib-1.10.2-install
+
+This will produce an error: `configure: error: libbzip2 development files not found`. 
+**Why did we get this error?** Following the example above, we confirmed that bzip2 library 
+was present when we ran `ls /usr/lib64 | grep libbz2`, but if you look closer, additional 
+information was provided in the error message:
+
+	The CRAM format may use bzip2 compression, which is implemented in HTSlib
+	by using compression routines from libbzip2 <http://www.bzip.org/>.
+
+	Building HTSlib requires libbzip2 development files to be installed on the
+	build machine; you may need to ensure a package such as libbz2-dev (on Debian
+	or Ubuntu Linux) or bzip2-devel (on RPM-based Linux distributions or Cygwin)
+	is installed.
+	
+	Either configure with --disable-bz2 (which will make some CRAM files
+	produced elsewhere unreadable) or resolve this error to build HTSlib. 
+
+What this means is that the bzip2 libraries on the login node don't include support 
+for certain HTSlib features, specifically CRAM file format support. If your work does 
+not depend on CRAM format support, then repeat the `configure` step using the flag provided 
+in the error message to disable these features:
+
+	./configure --prefix=$HOME/htslib-1.10.2-install --disable-bz2
+
+For this example compilation, we will assume that CRAM file format support is not required. 
+However, see [below](#something) for details about getting full bzip2 support for HTSlib and 
+Samtools.
+
+ 
+	make
+	make

--- a/start/software/software-overview.md
+++ b/start/software/software-overview.md
@@ -9,51 +9,62 @@ In general, OSG Connect can support most popular, open source software that fit 
 high throughput computing model. At present, we do not have or support most commercial software 
 due to licensing issues. 
 
-Here we review options for using preinstalled software packages via modules, software available as 
-precompiled binaries, software installed by users, and software available via containers.
+Here we review options, and provide links to additonal information, for using software 
+installed by users, software available as precompiled binaries or via containers, and 
+preinstalled software via modules.
+
+## Install Your Own Software
+
+For most cases, it will be advantageous for you to install the software needed for your jobs. 
+This not only gives you the greatest control over your computing environment, but will also
+make your jobs more distributable, allowing you to run jobs at more locations.
+
+Installing your own software can be performed interactively on your assigned login server. More 
+information about how to install your own software from source code can be found at 
+[Compiling Software for OSG Connect](https://support.opensciencegrid.org/support/solutions/articles/5000652099). 
+When installing software on the login node, your software will be specifically compiled against 
+the Red Hat Enterprise Linux (RHEL) 7 OS used on the login nodes. In most cases, subsequent 
+jobs that use this software will also need to run on a RHEL 7 OS which can be specified by the 
+`requirements` attribute of your HTCondor submit files - an example is provided in the software 
+compilation guide linked above. Be sure to also review our 
+[Introduction to Data Management on OSG Connect](https://support.opensciencegrid.org/support/solutions/articles/12000002985) 
+guide to determine the appropriate method for transferring software with your jobs.
+
+## Use Precompiled Binaries and Prebuilt Executables
+
+Some software may be available as a precompiled binary or prebuilt executable 
+which provides a quick and easy way to run a program without the need for installation 
+from source code. Binaries and executables are software files that are ready to 
+run as is, however binaries should always be tested beforehand. There are several 
+important considerations for using precompiled binaries in OSG 
+Connect: 1.) only binary files compiled against a Linux operating system are suitable 
+for use in OSG, 2.) some softwares have system and hardware dependencies that must 
+be met in order to run properly, and 3.) the available binaries may not have been 
+compiled with the feaures or configuration needed for your work.
+
+## Use Docker and Singularity Containers
+
+Container systems provide users with customizable and reproducable computing and software 
+environments. OSG Connect is compatible with both Singularity and Docker containers - the 
+latter will be converted to a Singularity image and added to the OSG Connect container image 
+repository. Users can choose from a set of pre-defined containers already availble within OSG 
+Connect or can use published or custom made containers. More details on how to use containers in OSG 
+Connect can be found in our 
+[Docker and Singularity Containers](https://support.opensciencegrid.org/support/solutions/articles/12000024676) guide. 
 
 ## Access Software In Distributed Modules 
 
-Currently, OSG Connect provides over 200 preinstalled software, libraries, and compiliers via 
-distributed environment modules. Modules provide a streamlined option for working with different 
-software versions as well as managing library dependencies for software. To run jobs that use modules, 
-your HTCondor submit files must include additional `requirements` to direct your jobs
-to appropriate compute nodes within OSG.
+Currently, OSG Connect provides over 200 preinstalled software, libraries, and 
+compiliers via distributed environment modules. Modules provide a streamlined option 
+for working with different software versions as well as managing library dependencies for 
+software. To run jobs that use modules, your HTCondor submit files must include additional 
+`requirements` to direct your jobs to appropriate compute nodes within OSG.
 
 More details about using modules in OSG Connect can be found 
 [here](https://support.opensciencegrid.org/support/solutions/articles/12000048518). 
 
-## Use Precompiled Binaries and Prebuilt Executables
-
-Some software may be available as a precompiled binary or prebuilt executable which provides a quick 
-and easy way to run a program without the need for installation from source code. Binaries and executables 
-are software files that are ready to run as is, however binaries should always be tested beforehand. 
-There also are several important considerations for using precompiled binaries in OSG Connect: 1.) only binary 
-files compiled against a Linux operating are suitable for use in OSG 2.) some softwares have system and 
-hardware dependencies that must be met in order to run properly and 3.) the available binaries may not have been 
-compiled with the feaures or configuration needed for your work.
-
-## Install Your Own Software
-
-For some users it may be necessary or advantageous to install their own software. This will be the case when
-your software is not available as a module or compatible precompiled binary, and/or when your work would benefit from 
-additional throughput that cannot be acheived with modules alone. More information about how to install 
-your own software from source code can be found at 
-[Compiling Application for OSG Connect](https://support.opensciencegrid.org/support/solutions/articles/5000652099). 
-Be sure to review our 
-[Introduction to Data Management on OSG Connect](https://support.opensciencegrid.org/support/solutions/articles/12000002985) 
-guide to determine the appropriate method for transferring software with your jobs.
-
-## Use Docker and Singularity Containers
-
-Container systems allow users full control over their computing and software environment. OSG Connect is 
-compatible with both Singularity and Docker containers - the latter will be converted to 
-a Singularity image and added to the OSG Connect container image repository. Users can choose from a set of 
-pre-defined containers already availble within OSG Connect or can use published or custom made 
-containers. More details on how to use containers in OSG Connect can be found in our 
-[Docker and Singularity Containers](https://support.opensciencegrid.org/support/solutions/articles/12000024676) guide. 
-
 ## Request Software For System-wide Installation via Modules
 
-If your work would benefit from system-wide installation of open source software (made available via modules), 
-please contact us at [support@opensciencegrid.org](mailto:support@opensciencegrid.org).
+If your work would benefit from system-wide installation of open source software (made 
+available via modules), please contact us at 
+[support@opensciencegrid.org](mailto:support@opensciencegrid.org).

--- a/update/freshpush.ini
+++ b/update/freshpush.ini
@@ -40,6 +40,7 @@ start/software/singularity-containers.md = 12000024676
 start/software/software-overview.md = 5000634395
 start/software/software-request.md = 5000649173
 start/software/container-how-to.md = 12000058245
+start/software/example-compilation.md = 12000074984
 
 ## Data management
 start/data/osgconnect-storage.md = 12000002985


### PR DESCRIPTION
Reorganized software overview guide, added info about login node OS. Major revision of previous application compilation guide to provide more information, guidance, and instruction to users.

Would like feedback on whether to add a "Use Your Compiled Software" section at end of compilation guide, idea would mostly be to point users to the /bin dir and about adding  software path the PATH for execution.