### PR TITLE
Remove transfer output files

### DIFF
--- a/examples/ml/tensorflow.md
+++ b/examples/ml/tensorflow.md
@@ -1,4 +1,4 @@
-[title]: - "TensorFlow"
+[title]: - "TensorFlow Jobs Guide"
 
 [TOC] 
 
@@ -22,7 +22,8 @@
 ## TensorFlow on OSG
 
 You can use TensorFlow on OSG by running your jobs through 
-[Singularity containers](https://support.opensciencegrid.org/solution/articles/12000024676-singularity-containers) .  We currently offer two containers (both based on Ubuntu):
+[Singularity containers](https://support.opensciencegrid.org/solution/articles/12000024676). 
+We currently offer two TensorFlow containers (both based on Ubuntu):
 
 1. __/cvmfs/singularity.opensciencegrid.org/opensciencegrid/tensorflow:latest__ is the
    CPU only version of TensorFlow. This runs slower, but OSG has many more CPU only
@@ -30,47 +31,44 @@ You can use TensorFlow on OSG by running your jobs through
 2. __/cvmfs/singularity.opensciencegrid.org/opensciencegrid/tensorflow-gpu:latest__ is a
    modified TensorFlow-GPU image to be used on the GPUs available on OSG.
 
-Note that there is still only a small number of GPUs available on OSG, so we 
-recommend the first image, at least to get started with.
+Note that there are limited GPU resources available on OSG, so we 
+recommend the non-gpu image, for first getting started.
 
 A sample job submit file for the CPU case is:
 
-
     # The UNIVERSE defines an execution environment. You will almost always use VANILLA.
-    Universe = vanilla
+    universe = vanilla
     
     # These are good base requirements for your jobs on OSG. It is specific on OS and
     # OS version, core cound and memory, and wants to use the software modules. 
-    Requirements = HAS_SINGULARITY == True
+    requirements = (HAS_SINGULARITY =?= True)
     request_cpus = 1
-    request_memory = 2 GB
-    request_disk = 4 GB
+    request_memory = <amount of memory>
+    request_disk = <amount of disk>
     
     # Singularity settings
     +SingularityImage = "/cvmfs/singularity.opensciencegrid.org/opensciencegrid/tensorflow:latest"
     
     # EXECUTABLE is the program your job will run It's often useful
     # to create a shell script to "wrap" your actual work.
-    Executable = job-wrapper.sh
-    Arguments = 
+    executable = job-wrapper.sh
+    arguments = <any arguments needed for job>
     
-    # inputs/outputs
+    # specify input files for job
     transfer_input_files = test.py
-    transfer_output_files = 
     
     # ERROR and OUTPUT are the error and output channels from your job
     # that HTCondor returns from the remote host.
-    Error = $(Cluster).$(Process).error
-    Output = $(Cluster).$(Process).output
+    error = $(Cluster).$(Process).error
+    output = $(Cluster).$(Process).output
     
     # The LOG file is where HTCondor places information about your
     # job's status, success, and resource consumption.
-    Log = $(Cluster).$(Process).log
+    log = $(Cluster).$(Process).log
     
     # QUEUE is the "start button" - it launches any jobs that have been
     # specified thus far.
-    Queue 1
-
+    queue 1
 
 This job is mapped to sites which support Singularity, and auto-loads the TensorFlow image. Your
 job will start inside the container under /srv.
@@ -79,47 +77,43 @@ The submit file for GPU jobs is similar, but with _request_gpus = 1_ and _+Singu
 set to the GPU image. Note that you might also need _CUDACapability_ in the requirements
 to make sure you land on a GPU new enough to support the feature set TensorFlow requires.
 
-
     # The UNIVERSE defines an execution environment. You will almost always use VANILLA.
-    Universe = vanilla
+    universe = vanilla
     
     # These are good base requirements for your jobs on OSG. It is specific on OS and
     # OS version, core cound and memory, and wants to use the software modules. 
-    Requirements = HAS_SINGULARITY == True && CUDACapability >= 3
-    request_cpus = 1
+    requirements = (HAS_SINGULARITY =?= True) && (CUDACapability >= 3)
     request_gpus = 1
-    request_memory = 2 GB
-    request_disk = 4 GB
+    request_cpus = 1
+    request_memory = <amount of memory>
+    request_disk = <amount of disk>
     
     # Singularity settings
     +SingularityImage = "/cvmfs/singularity.opensciencegrid.org/opensciencegrid/tensorflow-gpu:latest"
     
     # EXECUTABLE is the program your job will run It's often useful
     # to create a shell script to "wrap" your actual work.
-    Executable = job-wrapper.sh
-    Arguments = 
+    executable = job-wrapper.sh
+    arguments = <any arguments needed for job>
     
-    # inputs/outputs
+    # specify input files for job
     transfer_input_files = test.py
-    transfer_output_files = 
     
     # ERROR and OUTPUT are the error and output channels from your job
     # that HTCondor returns from the remote host.
-    Error = $(Cluster).$(Process).error
-    Output = $(Cluster).$(Process).output
+    error = $(Cluster).$(Process).error
+    output = $(Cluster).$(Process).output
     
     # The LOG file is where HTCondor places information about your
     # job's status, success, and resource consumption.
-    Log = $(Cluster).$(Process).log
+    log = $(Cluster).$(Process).log
     
     # QUEUE is the "start button" - it launches any jobs that have been
     # specified thus far.
-    Queue 1
-
+    queue 1
 
 When running on the GPU image, some extra control over the environment might be required.
 We recommend a job wrapper like:
-
 
     #!/bin/bash
 
@@ -128,4 +122,7 @@ We recommend a job wrapper like:
     # your own code here 
     python test.py gpu 1500
 
+## Additional Related Links
 
+[https://www.tensorflow.org/](https://www.tensorflow.org/)   
+[Docker and Singularity Containers in OSG Connect](https://support.opensciencegrid.org/support/solutions/articles/12000024676)

--- a/start/data/output-file-transfer-via-htcondor.md
+++ b/start/data/output-file-transfer-via-htcondor.md
@@ -64,8 +64,8 @@ output files or moving them to a subdirectory as a step in the bash
 executable script of your job -  only the output files that remain in the top-level 
 directory will be transferred back to your `/home` directory.
 
-In cases where a bash script is not used as the excutable of your job, please contact us 
-at [support@osgconnect.net](mailto:support@osgconnect.net).
+In cases where a bash script is not used as the excutable of your job and you wish to have only specific 
+output files transferred back, please contact us at [support@osgconnect.net](mailto:support@osgconnect.net).
 
 # Get Additional Options For Managing Job Output
 

--- a/start/data/output-file-transfer-via-htcondor.md
+++ b/start/data/output-file-transfer-via-htcondor.md
@@ -1,9 +1,6 @@
+[title]: - "Transfer Job Output <1GB In Size"
 
-[title]: - "Output File Transfer via HTCondor"
-
-# Output File Transfer via HTCondor
-
-## Overview
+# Overview
 
 When your OSG Connect jobs run, any output that gets generated is specifically written to 
 the execute node on which the job ran. In order to get access to your output files, a copy of 
@@ -12,25 +9,29 @@ the output must be transferred back to your OSG Connect login node.
 This guide will describe the necessary steps, along with important considerations, for transferring your 
 output files back to your `/home` directory on your OSG Connect login node. 
 
-## Important Considerations
+# Important Considerations
 
 As described in the [Introduction to Data Management on OSG Connect](https://support.opensciencegrid.org/support/solutions/articles/12000002985), 
 any output <1GB should be staged in your `/home` directory. For output files >1GB, 
 please refer to our [Transferring Data with StashCache](https://support.opensciencegrid.org/support/solutions/articles/12000002775) guide.
 
-By default, HTCondor will transfer any files that are generated during the execution of your job(s) 
-back to your `/home` directory, specifically to the directory from which the `condor_submit` 
-command was performed when submitting your job(s). However, this behavior only applies to files 
-in the top-level directory of where your job executes, meaning HTCondor will ignore any files 
-created in subdirectories of the job's main working directory (because HTCondor ignores subdirectories when determining what needs 
-to be transferred after the job completes). Several options exist for modifying this default output 
-file transfer behavior - to learn more please contact us at [support@osgconnect.net](mailto:support@osgconnect.net).
+# Use HTCondor To Transfer Output \<1GB
+
+*By default, HTCondor will transfer any files that are generated or modified during 
+the execution of your job(s) back to your `/home` directory*, specifically to the 
+directory from which the `condor_submit` command was performed when submitting your 
+job(s). However, this behavior only applies to files in the top-level directory of 
+where your job executes, meaning HTCondor will ignore any files 
+created in subdirectories of the job's main working directory (because HTCondor ignores 
+subdirectories when determining what needs to be transferred after the job completes). Several 
+options exist for modifying this default output file transfer behavior - to learn more 
+please contact us at [support@osgconnect.net](mailto:support@osgconnect.net).
 
 **If your jobs use any input files >1GB that are transferred from your `/public` directory 
 using StacheCash, it is important that these files get deleted from the job's working directory or moved to a 
 subdirectory so that HTCondor will not transfer these large files back to your `/home` directory.**
 
-### Managing Multiple Output Files
+## Group Multiple Output Files For Convenience
 
 If your jobs will generate multiple output files, we recommend combining all output into a compressed 
 tar archive for convenience, particularly when transferring your results to your local computer from 
@@ -52,26 +53,17 @@ was moved to `my_output`. Be sure to create `my_job.output.tar.gz` in the top-le
 your job executes and HTCondor will automatically transfer this tar archive back to your `/home` 
 directory.
 
-
 ## Select Specific Output Files To Transfer to `/home` Using HTCondor
 
 As described above, HTCondor will, by default, transfer any files that are generated during the 
 execution of your job(s) back to your `/home` directory. If your job(s) will produce multiple output 
 files but you only need to retain a subset of these output files, we recommend deleting the unrequired 
 output files or moving them to a subdirectory as a step in the bash 
-executable script of your job -  only the output files that remain in the top-level directory will be transferred 
-back to your `/home` directory.
+executable script of your job -  only the output files that remain in the top-level 
+directory will be transferred back to your `/home` directory.
 
-In cases where a bash script is not used as the excutable of your job, you can use `transfer_output_files` 
-in your HTCondor submit file to specify individual output files that should be transferred back to your 
-`/home` directory. For example, if you only wish to retain `my_job.output.csv` from a set of multiple 
-output files, use the following in your HTCondor submit file:
-
-	transfer_output_files = my_job.output.csv
-
-A note of caution when using the above: only this file will be transferred back to your `/home` directory 
-and if there is a typo in the file name, your job will go on hold and all progress will be lost. Be sure 
-to properly test the above submit file statement with your workflow before using for a large batch of jobs.
+In cases where a bash script is not used as the excutable of your job, please contact us 
+at [support@osgconnect.net](mailto:support@osgconnect.net).
 
 ## Get Additional Options For Managing Job Output
 

--- a/start/data/output-file-transfer-via-htcondor.md
+++ b/start/data/output-file-transfer-via-htcondor.md
@@ -15,7 +15,7 @@ output files back to your `/home` directory on your OSG Connect login node.
 
 As described in the [Introduction to Data Management on OSG Connect](https://support.opensciencegrid.org/support/solutions/articles/12000002985), 
 any output <1GB should be staged in your `/home` directory. For output files >1GB, 
-please refer to our [Transferring Data with StashCache](https://support.opensciencegrid.org/support/solutions/articles/12000002775) guide.
+please refer to our [Transfer Large Input and Output Files >1GB In Size](https://support.opensciencegrid.org/support/solutions/articles/12000002775) guide.
 
 # Use HTCondor To Transfer Output \<1GB
 

--- a/start/data/output-file-transfer-via-htcondor.md
+++ b/start/data/output-file-transfer-via-htcondor.md
@@ -1,5 +1,7 @@
 [title]: - "Transfer Job Output <1GB In Size"
 
+[TOC]
+
 # Overview
 
 When your OSG Connect jobs run, any output that gets generated is specifically written to 
@@ -65,7 +67,7 @@ directory will be transferred back to your `/home` directory.
 In cases where a bash script is not used as the excutable of your job, please contact us 
 at [support@osgconnect.net](mailto:support@osgconnect.net).
 
-## Get Additional Options For Managing Job Output
+# Get Additional Options For Managing Job Output
 
 Several options exist for managing output file transfers back to your `/home` directory and we 
 encourage you to get in touch with us at [support@osgconnect.net](mailto:support@osgconnect.net) to 


### PR DESCRIPTION
Lauren asked that all examples of transfer_output_files be removed from connectbook docs