### PR TITLE
display less than symbol title

### DIFF
--- a/start/data/file-transfer-via-htcondor.md
+++ b/start/data/file-transfer-via-htcondor.md
@@ -1,4 +1,4 @@
-[title]: - "Transfer Input Files `<`100MB In Size"
+[title]: - "Transfer Input Files < 100MB In Size"
 
 [TOC] 
 

--- a/start/data/output-file-transfer-via-htcondor.md
+++ b/start/data/output-file-transfer-via-htcondor.md
@@ -1,4 +1,4 @@
-[title]: - "Transfer Job Output `<`1GB In Size"
+[title]: - "Transfer Job Output < 1GB In Size"
 
 [TOC]
 


### PR DESCRIPTION
another attempt at displaying "<" symbol in article title (back ticks failed, \&lt; failed...) 