### PR TITLE
first run through of python package rewrite

### DIFF
--- a/examples/build-python.md
+++ b/examples/build-python.md
@@ -91,6 +91,7 @@ the OSG provided versions of Python, you have created your own.
 	Once this tar.gz file is created, move it to your public directory: 
 
 		$ mv python.tar.gz /public/username
+Once you confirm that this file was moved to your public folder successfully, we can delete the remaining files in our build_dir folder to help maintain a clean workspace. We can delete them by typing: 
 
 7. **Submit jobs**
 

--- a/examples/build-python.md
+++ b/examples/build-python.md
@@ -35,7 +35,7 @@ the OSG provided versions of Python, you have created your own.
 
 		$ mkdir build_dir
 		$ cd build_dir
-		$ cp ~/Python-3.9.10.tgz ./ # or do the download now
+		$ cp ~/Python-3.9.10.tgz ./ #  The Python source code could alternatively be downloaded *directly* into this folder.
 		$ mkdir python
 
 3. **Start a singularity container**
@@ -70,7 +70,7 @@ the OSG provided versions of Python, you have created your own.
 
 5. **Check installation**
 
-	The `python` directory should now have subdirectories `bin`, `include`, `lib` and `share`
+	The `python` directory should now have subdirectories `bin`, `include`, `lib` and `share`.
 
 		$ ls python
 		bin  include  lib  share

--- a/examples/build-python.md
+++ b/examples/build-python.md
@@ -1,0 +1,101 @@
+[title]: - "Build a Copy of Python"
+
+[TOC]
+
+# Overview
+
+This guide shows how to build a compiled copy of the Python interpreter and 
+runtime environment. It is meant to be used along with 
+our [Run Python Scripts on the OS Pool][python-pkgs] guide, where instead of using 
+the OSG provided versions of Python, you have created your own. 
+
+# Create Python Installation
+
+1. **Download Python source code**
+
+	Choose the version of Python you would like to build from the main 
+	[Python website](https://www.python.org/downloads/source/). Download the "Gzipped 
+	source tarball" (a .tgz file) to your home 
+	directory on OSG Connect; if you have the link, you can do this using the 
+	`wget` command, for example: 
+
+		$ wget https://www.python.org/ftp/python/3.9.10/Python-3.9.10.tgz
+
+2. **Create installation directories**
+
+	Create a main "build" directory, and place the downloaded Python source code inside. 
+	Create a second subdirectory -- in what follows, we have called this subdirectory `python`. 
+	The final directory structure should looks something like this:
+
+		├── build_dir/
+		│   └── python/ 
+		│   └── Python-3.9.10.tgz
+
+	and can be created using a sequence of commands like: 
+
+		$ mkdir build_dir
+		$ cd build_dir
+		$ cp ~/Python-3.9.10.tgz ./ # or do the download now
+		$ mkdir python
+
+3. **Start a singularity container**
+
+	The login node does not have everything we need to build Python, so we 
+	are going to use a singularity container instead. Run the following command 
+	from the main build directory: 
+
+		$ singularity shell \
+					--home $PWD:/srv \
+					--pwd /srv \
+					--bind /cvmfs \
+					--scratch /var/tmp \
+					--scratch /tmp \
+					--contain --ipc --pid \
+					/cvmfs/singularity.opensciencegrid.org/opensciencegrid/osgvo-el7:latest
+
+4. **Un-tar source code and compile Python**
+
+	Run the following commands to un-tar the .tgz source code file and 
+	compile Python, installing it to the `python` subdirectory created earlier: 
+
+		$ tar -xzf Python-3.9.10.tgz
+		$ cd Python-3.9.10
+		$ ./configure --prefix=/srv/python
+		$ make; make install
+		$ cd ..
+
+	Once these commands are done, you can exit the container: 
+
+		$ exit
+
+5. **Check installation**
+
+	The `python` directory should now have subdirectories `bin`, `include`, `lib` and `share`
+
+		$ ls python
+		bin  include  lib  share
+
+	Run a quick check of the python program by running: 
+
+		$ python/bin/python3 --version
+
+6. **Prepare the installation directory for jobs**
+
+	Combine and compress the `python` installation directory to a tar.gz file: 
+
+		$ tar -czf python.tar.gz python
+
+	You may want to include the version number in the name of the tar.gz file if you 
+	are planning to work with different versions of Python. 
+
+	Once this tar.gz file is created, move it to your public directory: 
+
+		$ mv python.tar.gz /public/username
+
+7. **Submit jobs**
+
+	From here, follow the instructions in our [Run Python Scripts on the OS Pool][python-pkgs] 
+	guide, replacing the `stash:///osgconnect/public/osg` links with links to the copy of 
+	Python in your own `/public` directory. 
+
+[python-pkgs]: 

--- a/examples/build-python.md
+++ b/examples/build-python.md
@@ -91,7 +91,14 @@ the OSG provided versions of Python, you have created your own.
 	Once this tar.gz file is created, move it to your public directory: 
 
 		$ mv python.tar.gz /public/username
-Once you confirm that this file was moved to your public folder successfully, we can delete the remaining files in our build_dir folder to help maintain a clean workspace. We can delete them by typing: 
+
+	Once you confirm that this file was moved to your public folder 
+	successfully, you can delete the remaining files in our `build_dir` folder to 
+	help maintain a clean workspace. We can delete them by typing: 
+	
+		$ rm -r python Python-3.9.10 Python-3.9.10.tgz
+
+	You can also remove the entire build directory. 
 
 7. **Submit jobs**
 

--- a/examples/build-python.md
+++ b/examples/build-python.md
@@ -58,11 +58,11 @@ the OSG provided versions of Python, you have created your own.
 	Run the following commands to un-tar the .tgz source code file and 
 	compile Python, installing it to the `python` subdirectory created earlier: 
 
-		$ tar -xzf Python-3.9.10.tgz
-		$ cd Python-3.9.10
-		$ ./configure --prefix=/srv/python
-		$ make; make install
-		$ cd ..
+		Singularity> tar -xzf Python-3.9.10.tgz
+		Singularity> cd Python-3.9.10
+		Singularity> ./configure --prefix=/srv/python
+		Singularity> make; make install
+		Singularity> cd ..
 
 	Once these commands are done, you can exit the container: 
 

--- a/examples/manage-python-packages.md
+++ b/examples/manage-python-packages.md
@@ -56,7 +56,7 @@ next section of the guide: [Submit Python Jobs](#submit-python-jobs)
 	
 		$ which python3
 	
-	The output line should start with your home directory. 
+	The output line should start with your home directory or with a tilde (~) indicating the path of your home directory.
 
 1. **Create Packages Directory**
 	
@@ -112,7 +112,7 @@ that unzips the OSG-provided copy of Python and your own Python packages, then
 executes your Python script. 
 
 A sample script appears below. After the first line, the lines starting
-with hash marks are comments . You should replace \"myscript.py\" with
+with hash marks are comments. You should replace \"myscript.py\" with
 the name of the script you would like to run, and modify the Python
 version numbers to be the same as what you used above to install your
 packages.

--- a/examples/manage-python-packages.md
+++ b/examples/manage-python-packages.md
@@ -20,10 +20,9 @@ OSG Connect provides a pre-built copy of the following versions of Python:
   | Python 3.9 | python39.tar.gz |
 
 If you need a specific version of Python not shown 
-above, [contact us][get-help] to 
-see if we can build it for you; if 
-we can't, we can send you instructions for how to build your own copy of Python 
-or use a Singularity container for running your jobs. 
+above, see our [Build a Copy of Python][python-build] guide to create
+your own. If you have questions about this process, or alternatives 
+when using different versions of Python, [contact us][get-help].
 
 # Install Python Packages
 
@@ -198,3 +197,4 @@ team  at [support@opensciencegrid.org](mailto:support@opensciencegrid.org) or vi
 [module-guide]: 12000048518
 [data-intro]: 12000002985
 [get-help]: 12000084585
+[python-build]: TBD 

--- a/examples/manage-python-packages.md
+++ b/examples/manage-python-packages.md
@@ -25,20 +25,26 @@ see if we can build it for you; if
 we can't, we can send you instructions for how to build your own copy of Python 
 or use a Singularity container for running your jobs. 
 
-# Install Python packages
+# Install Python Packages
 
-It's likely that you'll need additional Python *packages* (aka *libraries* or *modules*) 
-that are not
+It's likely that your jobs will need additional Python *packages* 
+(aka *libraries* or *modules*) that are not
 present in the base Python installations provided by OSG staff. This portion of the
 guide describes how to install packages to a specific location in your home directory
 using `pip`. 
 
-1. Get a Copy of Python
+1. **Get a Copy of Python**
 
-	Use the command `wget` to download a copy of Python from OSG Connect's "public" data space: 
-		$ wget http://stash.osgconnect.net/public/osg/python/python37.tar.gz
+	OSG Connect's pre-built copies of Python are located at the path `/public/osg/python`. 
+	You can see available versions by running:
+	
+		$ ls -l /public/osg/python
+	
+	To get started, choose your desired version and copy it to your current directory:
+	
+		$ cp /public/osg/python/python##.tar.gz ./
 
-1. Set Up Python
+1. **Set Up Python**
 
 	Unzip the copied Python installation and set the `PATH` variable to indicate 
 	where to find the `python` and `pip` commands. 
@@ -50,9 +56,9 @@ using `pip`.
 	
 		$ which python3
 	
-	It should return a path that starts with your home directory. 
+	The output line should start with your home directory. 
 
-1. Create Packages Directory
+1. **Create Packages Directory**
 	
 	Create a directory to hold your installed Python packages. 
 	
@@ -63,7 +69,7 @@ using `pip`.
 	choose a different name than `python-packages`, make sure to replace the 
 	directory name as appropriate in the following commands and examples. 
 
-1. Install Packages
+1. **Install Packages**
 
 	Install the packages you need with the `pip` command. 
 	
@@ -79,7 +85,7 @@ using `pip`.
 	
 		$ ls python-packages
 
-1. Prepare Packages Directory for Jobs
+1. **Prepare Packages Directory for Jobs**
 
 	Finally, when sending the packages along with jobs, it is helpful to "squash" 
 	the directory into a single, compressed "tar.gz" file, which can be done with 
@@ -112,7 +118,7 @@ packages.
 
 	# set the location of your Python installation and packages
 	export PATH=$PWD/python/bin:$PATH
-	export PYTHONPATH=$PWD/packages
+	export PYTHONPATH=$PWD/python-packages
 	export HOME=$PWD
 
 	# run your script
@@ -123,7 +129,8 @@ you can add them to this base script.
 
 ## Create an HTCondor Submit File
 
-In order to submit `run_py.sh` (created in the previous step) as part of a job, we 
+In order to submit `run_py.sh` (created in the previous step) and our Python script 
+and packages as part of a job, we 
 need to create an HTCondor submit file. This file should include the following:
 
 * `run_py.sh` specified as the executable
@@ -137,19 +144,19 @@ All together, the submit file will look something like this:
 
 	# transfer Python script, packages, and base Python installation
 	# remove the packages tar.gz file if not using
-	transfer_input_files = myscript.py, packages.tar.gz, stash://python37.tar.gz
+	transfer_input_files = python##.tar.gz, python-packages.tar.gz, myscript.py
 
 	log         = job.log
 	output      = job.out
 	error       = job.error
-
-	requirements = (OSGVO_OS_STRING == "RHEL 7")
 
 	request_cpus 	= 1 
 	request_memory 	= 2GB
 	request_disk 	= 2GB
 
 	queue 1
+
+Submit the job as usual using `condor_submit`. 
 
 # Other Considerations
 

--- a/examples/manage-python-packages.md
+++ b/examples/manage-python-packages.md
@@ -93,6 +93,15 @@ using `pip`.
 	
 		$ tar -czf python-packages.tar.gz python-packages
 
+1. **Check Size of Package Tar File**
+
+	Check the size of the new `python-packages.tar.gz` file:
+	
+		$ ls -lh python-packages.tar.gz
+	
+	If it is larger than 100MB, it should be moved to your `/public` directory 
+	and copied to jobs via a stash link. If it is smaller than 
+
 # Submit Python Jobs
 
 ## Create an Script to Set Up and Run Python
@@ -134,8 +143,10 @@ and packages as part of a job, we
 need to create an HTCondor submit file. This file should include the following:
 
 * `run_py.sh` specified as the executable
-* use `transfer_input_files` to bring along the Python tar.gz file, our packages (if 
-using) and the Python script (`myscript.py` in this example)
+* use `transfer_input_files` to bring along the Python script 
+(`myscript.py` in this example), our packages (if 
+using) and the original Python tar.gz file from `/public/osg` (using the 
+correct "stash" formatted link to the file).
 
 All together, the submit file will look something like this: 
 
@@ -144,7 +155,8 @@ All together, the submit file will look something like this:
 
 	# transfer Python script, packages, and base Python installation
 	# remove the packages tar.gz file if not using
-	transfer_input_files = python##.tar.gz, python-packages.tar.gz, myscript.py
+	transfer_input_files = myscript.py, python-packages.tar.gz, \
+						   stash:///osgconnect/public/osg/python/v1/python##.tar.gz
 
 	log         = job.log
 	output      = job.out
@@ -155,6 +167,12 @@ All together, the submit file will look something like this:
 	request_disk 	= 2GB
 
 	queue 1
+
+**Note on File Sizes** If you are using 
+packages and placed them into your `/public` directory (see note on checking the 
+size [above]()), make sure to change the name of the packages tar.gz file in
+`transfer_input_files` line to the correct "stash" format -- see more information 
+in [this guide about transferring larger files](5000639798). 
 
 Submit the job as usual using `condor_submit`. 
 

--- a/examples/manage-python-packages.md
+++ b/examples/manage-python-packages.md
@@ -31,9 +31,10 @@ It's likely that your jobs will need additional Python *packages*
 (aka *libraries* or *modules*) that are not
 present in the base Python installations provided by OSG staff. This portion of the
 guide describes how to install packages to a specific location in your home directory
-using `pip`. 
+using `pip`. If you do not need any additional packages, proceeded to the 
+next section of the guide: [Submit Python Jobs](#submit-python-jobs)
 
-1. **Get a Copy of Python**
+1. **Get a Copy of OSG-Provided Python**
 
 	OSG Connect's pre-built copies of Python are located at the path `/public/osg/python`. 
 	You can see available versions by running:
@@ -78,7 +79,7 @@ using `pip`.
 	> The last values should be the names of your packages. So if I wanted to install 
 	> `numpy` and `pandas` to my `python-packages` folder, I should run:  
 	> 
-	> 	$ python3 -m pip install --target=$PWD/python-packages numpy pandas
+	>     $ python3 -m pip install --target=$PWD/python-packages numpy pandas
 	
 	You can confirm that your packages were installed by listing the contents of 
 	the package directory -- you should see your main packages and their dependencies: 
@@ -100,7 +101,8 @@ using `pip`.
 		$ ls -lh python-packages.tar.gz
 	
 	If it is larger than 100MB, it should be moved to your `/public` directory 
-	and copied to jobs via a stash link. If it is smaller than 
+	and copied to jobs via a stash link. If it is smaller than 100MB, it can 
+	remain in your `/home` directory. 
 
 # Submit Python Jobs
 
@@ -154,9 +156,10 @@ All together, the submit file will look something like this:
 	executable 	= run_py.sh
 
 	# transfer Python script, packages, and base Python installation
-	# remove the packages tar.gz file if not using
+	# remove the python-packages tar.gz file if not using
+	# see note below in user guide about python-packages.tar.gz > 100MB
 	transfer_input_files = myscript.py, python-packages.tar.gz, \
-						   stash:///osgconnect/public/osg/python/v1/python##.tar.gz
+						   stash:///osgconnect/public/osg/python/python##.tar.gz
 
 	log         = job.log
 	output      = job.out


### PR DESCRIPTION
When testing, don't use /public/osg as the home of the python tar.gz files, but use /public/ckoch5. 