### PR TITLE
Push modified files only

### DIFF
--- a/.github/workflows/publish-workflow.yml
+++ b/.github/workflows/publish-workflow.yml
@@ -22,5 +22,5 @@ jobs:
       - name: Run the update script
         run: |
             cd /tmp/connectbook
-            ./update/update.sh
+            ./update/update.sh $(git diff --name-only HEAD HEAD~1  | tr '\n' ' ')
 

--- a/.github/workflows/publish-workflow.yml
+++ b/.github/workflows/publish-workflow.yml
@@ -22,5 +22,5 @@ jobs:
       - name: Run the update script
         run: |
             cd /tmp/connectbook
-            ./update/update.sh $(git diff --name-only HEAD HEAD~1  | tr '\n' ' ')
+            ./update/update.sh $(diff --name-only HEAD HEAD~1 | grep \.md | tr '\n' ' ')
 

--- a/update/update.sh
+++ b/update/update.sh
@@ -9,10 +9,8 @@ echo child pid: $$
 echo dir: $(pwd)
 
 if [ $# -eq 0 ]; then
-	echo 'files: (discovered)'
-	generator () {
-		find . -name \*.md -print
-	}
+  echo "No Files to Change: Skipping Update"
+	exit 0
 else
 	echo files: "$@"
 	generator () {


### PR DESCRIPTION
Currently all files are pushed when Freshdesk is updated, which overwrites the modified_on metadata for all the articles to be the most recent push date.

This change just pushes the changed files.