### PR TITLE
Revert "Merge pull request #142 from CannonLock/push-modified"

### DIFF
--- a/.github/workflows/publish-workflow.yml
+++ b/.github/workflows/publish-workflow.yml
@@ -22,5 +22,5 @@ jobs:
       - name: Run the update script
         run: |
             cd /tmp/connectbook
-            ./update/update.sh $(diff --name-only HEAD HEAD~1 | grep \.md | tr '\n' ' ')
+            ./update/update.sh
 

--- a/update/update.sh
+++ b/update/update.sh
@@ -9,8 +9,10 @@ echo child pid: $$
 echo dir: $(pwd)
 
 if [ $# -eq 0 ]; then
-  echo "No Files to Change: Skipping Update"
-	exit 0
+	echo 'files: (discovered)'
+	generator () {
+		find . -name \*.md -print
+	}
 else
 	echo files: "$@"
 	generator () {


### PR DESCRIPTION
My previous fix does not account for the commits that are made in tutorial submodules and will not push them to Freshdesk.

This reverts commit 699fc03e3cf9462450cf0844021e0e98f2a259f8, reversing
changes made to 7c8fd93241b41c77e3c416989737cbb57d3846f6.

I am testing the submodules fix currently but until it is ready it is best this is reverted. 